### PR TITLE
Refactor/styles initial config

### DIFF
--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -3,5 +3,6 @@
   "rules": {
     "selector-class-pattern": null,
     "scss/double-slash-comment-whitespace-inside": "always"
-  }
+  },
+  "ignoreFiles": ["**/normalize.css"]
 }

--- a/src/assets/fonts/fonts.scss
+++ b/src/assets/fonts/fonts.scss
@@ -1,0 +1,49 @@
+@font-face {
+  font-family: Germano;
+  font-style: normal;
+  font-display: swap;
+  src:
+    url('../assets/fonts/Germano-Regular.woff2') format('woff2'),
+    url('../assets/fonts/Germano-Regular.woff') format('woff');
+}
+
+@font-face {
+  font-family: 'GOST type B';
+  font-style: normal;
+  font-display: swap;
+  src:
+    url('../assets/fonts/GOST_type_B.woff2') format('woff2'),
+    url('../assets/fonts/GOST_type_B.woff') format('woff');
+}
+
+@font-face {
+  font-family: Molot;
+  font-style: normal;
+  font-display: block;
+  src:
+    url('../assets/fonts/Molot.woff2') format('woff2'),
+    url('../assets/fonts/Molot.woff') format('woff');
+}
+
+// aliases for css exported from figma
+
+@font-face {
+  font-family: Germano-Regular;
+  src:
+    url('../assets/fonts/Germano-Regular.woff2') format('woff2'),
+    url('../assets/fonts/Germano-Regular.woff') format('woff');
+}
+
+@font-face {
+  font-family: GostTypeB-Standard;
+  src:
+    url('../assets/fonts/GOST_type_B.woff2') format('woff2'),
+    url('../assets/fonts/GOST_type_B.woff') format('woff');
+}
+
+@font-face {
+  font-family: Molot-Regular;
+  src:
+    url('../assets/fonts/Molot.woff2') format('woff2'),
+    url('../assets/fonts/Molot.woff') format('woff');
+}

--- a/src/styles/index.scss
+++ b/src/styles/index.scss
@@ -2,7 +2,6 @@
 
 @font-face {
   font-family: 'Germano Regular';
-  font-weight: 400;
   font-style: normal;
   font-display: swap;
   src:
@@ -12,7 +11,6 @@
 
 @font-face {
   font-family: 'GOST type B';
-  font-weight: 400;
   font-style: normal;
   font-display: swap;
   src:
@@ -22,9 +20,8 @@
 
 @font-face {
   font-family: Molot;
-  font-weight: 400;
   font-style: normal;
-  font-display: swap;
+  font-display: block;
   src:
     url('../assets/fonts/Molot.woff2') format('woff2'),
     url('../assets/fonts/Molot.woff') format('woff');

--- a/src/styles/index.scss
+++ b/src/styles/index.scss
@@ -1,31 +1,6 @@
-@use './normalize.css';
-
-@font-face {
-  font-family: 'Germano Regular';
-  font-style: normal;
-  font-display: swap;
-  src:
-    url('../assets/fonts/Germano-Regular.woff2') format('woff2'),
-    url('../assets/fonts/Germano-Regular.woff') format('woff');
-}
-
-@font-face {
-  font-family: 'GOST type B';
-  font-style: normal;
-  font-display: swap;
-  src:
-    url('../assets/fonts/GOST_type_B.woff2') format('woff2'),
-    url('../assets/fonts/GOST_type_B.woff') format('woff');
-}
-
-@font-face {
-  font-family: Molot;
-  font-style: normal;
-  font-display: block;
-  src:
-    url('../assets/fonts/Molot.woff2') format('woff2'),
-    url('../assets/fonts/Molot.woff') format('woff');
-}
+@import './normalize.css';
+@import './variables/global';
+@import '../assets/fonts/fonts';
 
 ul,
 li {

--- a/src/styles/index.scss
+++ b/src/styles/index.scss
@@ -26,3 +26,15 @@
     url('../assets/fonts/Molot.woff2') format('woff2'),
     url('../assets/fonts/Molot.woff') format('woff');
 }
+
+ul,
+li {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+a {
+  color: inherit;
+  text-decoration: none;
+}

--- a/src/styles/variables/global.scss
+++ b/src/styles/variables/global.scss
@@ -1,24 +1,188 @@
-$white: #fff; // фон
-$dark-blue: #002d63; // текст
-$dark-blue-50: #8096b1; // То, что не должно сильно бросаться в глаза — иконки для исправления и т.п.
-$shadow: #002c6180; // Затемнение заднего фона
-$shadow-for-header: #ffffff80; // полупрозрачность заднего фона
-$white-60: #a8bed8; // Вместо полупрозрачного белого на тёмном фоне
-$electric: #0049d8; // Заголовки + фон контакты он же
+/* Figma Styles of your File */
+:root {
+  /* Colors */
+  --black: #111;
+  --darkblue: #002d63;
+  --electric: #0049d8;
+  --white: #fff;
+  --radialblue: radial-gradient(closest-side, rgb(0 73 216 / 100%) 0%, rgb(255 255 255 / 0%) 100%);
+  --radialblue-45: radial-gradient(
+    closest-side,
+    rgb(3 64 137 / 45%) 0%,
+    rgb(255 255 255 / 0%) 100%
+  );
+  --darkblue-50: #8096b1;
+  --gradient: linear-gradient(
+    0deg,
+    rgb(12 52 131 / 100%) 1%,
+    rgb(71 103 167 / 100%) 26%,
+    rgb(162 182 223 / 100%) 60%,
+    rgb(255 255 255 / 100%) 88%
+  );
+  --gradient-bg: linear-gradient(
+    0.23deg,
+    rgb(12 52 131 / 100%) 0%,
+    rgb(162 182 223 / 100%) 100%,
+    rgb(107 140 206 / 100%) 100%
+  );
+  --white-60: #a8bed8;
+  --error: #bf1700;
+  --shadow: rgb(0 45 99 / 50%);
+  --shadowforheader: linear-gradient(90deg, rgb(255 255 255 / 0%) 0%, rgb(255 255 255 / 50%) 100%);
+  --errorfordark: #fa391f;
 
-$radial-blue-center: $electric; // Подложки под кнопки и фото
-$radial-blue-45-center: #033e8773; // Подложки под кнопки и фото, если они не активны
+  /* Fonts */
+  --title-h-1-font-family: germano-regular, sans-serif;
+  --title-h-1-font-size: 140px;
+  --title-h-1-line-height: 120px;
+  --title-h-1-font-weight: 400;
+  --title-h-1-font-style: normal;
+  --title-h-3-font-family: germano-regular, sans-serif;
+  --title-h-3-font-size: 64px;
+  --title-h-3-line-height: 64px;
+  --title-h-3-font-weight: 400;
+  --title-h-3-font-style: normal;
+  --title-h-3-line-font-family: germano-regular, sans-serif;
+  --title-h-3-line-font-size: 64px;
+  --title-h-3-line-line-height: 64px;
+  --title-h-3-line-font-weight: 400;
+  --title-h-3-line-font-style: normal;
+  --title-h-4-font-family: germano-regular, sans-serif;
+  --title-h-4-font-size: 48px;
+  --title-h-4-line-height: 48px;
+  --title-h-4-font-weight: 400;
+  --title-h-4-font-style: normal;
+  --title-h-4-line-font-family: germano-regular, sans-serif;
+  --title-h-4-line-font-size: 48px;
+  --title-h-4-line-line-height: 48px;
+  --title-h-4-line-font-weight: 400;
+  --title-h-4-line-font-style: normal;
+  --title-h-1-molot-font-family: molot-regular, sans-serif;
+  --title-h-1-molot-font-size: 128px;
+  --title-h-1-molot-line-height: 128px;
+  --title-h-1-molot-font-weight: 400;
+  --title-h-1-molot-font-style: normal;
+  --title-h-2-molot-font-family: molot-regular, sans-serif;
+  --title-h-2-molot-font-size: 100px;
+  --title-h-2-molot-line-height: 100px;
+  --title-h-2-molot-font-weight: 400;
+  --title-h-2-molot-font-style: normal;
+  --title-h-3-molot-font-family: molot-regular, sans-serif;
+  --title-h-3-molot-font-size: 80px;
+  --title-h-3-molot-line-height: 80px;
+  --title-h-3-molot-font-weight: 400;
+  --title-h-3-molot-font-style: normal;
+  --title-h-4-molot-font-family: molot-regular, sans-serif;
+  --title-h-4-molot-font-size: 66px;
+  --title-h-4-molot-line-height: 66px;
+  --title-h-4-molot-font-weight: 400;
+  --title-h-4-molot-font-style: normal;
+  --title-h-1-1280-font-family: germano-regular, sans-serif;
+  --title-h-1-1280-font-size: 100px;
+  --title-h-1-1280-line-height: 120px;
+  --title-h-1-1280-font-weight: 400;
+  --title-h-1-1280-font-style: normal;
+  --title-h-2-font-family: germano-regular, sans-serif;
+  --title-h-2-font-size: 80px;
+  --title-h-2-line-height: 80px;
+  --title-h-2-font-weight: 400;
+  --title-h-2-font-style: normal;
+  --title-h-2-line-font-family: germano-regular, sans-serif;
+  --title-h-2-line-font-size: 80px;
+  --title-h-2-line-line-height: 80px;
+  --title-h-2-line-font-weight: 400;
+  --title-h-2-line-font-style: normal;
+  --title-tel-h-1-molot-font-family: molot-regular, sans-serif;
+  --title-tel-h-1-molot-font-size: 40px;
+  --title-tel-h-1-molot-line-height: 40px;
+  --title-tel-h-1-molot-font-weight: 400;
+  --title-tel-h-1-molot-font-style: normal;
+  --title-tel-h-2-molot-font-family: molot-regular, sans-serif;
+  --title-tel-h-2-molot-font-size: 30px;
+  --title-tel-h-2-molot-line-height: 30px;
+  --title-tel-h-2-molot-font-weight: 400;
+  --title-tel-h-2-molot-font-style: normal;
+  --title-tel-h-1-font-family: germano-regular, sans-serif;
+  --title-tel-h-1-font-size: 40px;
+  --title-tel-h-1-line-height: 40px;
+  --title-tel-h-1-font-weight: 400;
+  --title-tel-h-1-font-style: normal;
+  --title-tel-h-2-font-family: germano-regular, sans-serif;
+  --title-tel-h-2-font-size: 32px;
+  --title-tel-h-2-line-height: 32px;
+  --title-tel-h-2-font-weight: 400;
+  --title-tel-h-2-font-style: normal;
+  --title-tel-h-2-line-font-family: germano-regular, sans-serif;
+  --title-tel-h-2-line-font-size: 32px;
+  --title-tel-h-2-line-line-height: 32px;
+  --title-tel-h-2-line-font-weight: 400;
+  --title-tel-h-2-line-font-style: normal;
+  --title-tel-h-3-font-family: germano-regular, sans-serif;
+  --title-tel-h-3-font-size: 24px;
+  --title-tel-h-3-line-height: 24px;
+  --title-tel-h-3-font-weight: 400;
+  --title-tel-h-3-font-style: normal;
+  --title-tel-h-1-line-font-family: germano-regular, sans-serif;
+  --title-tel-h-1-line-font-size: 40px;
+  --title-tel-h-1-line-line-height: 40px;
+  --title-tel-h-1-line-font-weight: 400;
+  --title-tel-h-1-line-font-style: normal;
+  --text-1-font-family: gosttypeb-standard, sans-serif;
+  --text-1-font-size: 32px;
+  --text-1-line-height: 38px;
+  --text-1-font-weight: 400;
+  --text-1-font-style: normal;
+  --text-1-line-font-family: gosttypeb-standard, sans-serif;
+  --text-1-line-font-size: 32px;
+  --text-1-line-line-height: 38px;
+  --text-1-line-font-weight: 400;
+  --text-1-line-font-style: normal;
+  --text-2-font-family: gosttypeb-standard, sans-serif;
+  --text-2-font-size: 24px;
+  --text-2-line-height: 28px;
+  --text-2-font-weight: 400;
+  --text-2-font-style: normal;
+  --text-2-line-font-family: gosttypeb-standard, sans-serif;
+  --text-2-line-font-size: 24px;
+  --text-2-line-line-height: 28px;
+  --text-2-line-font-weight: 400;
+  --text-2-line-font-style: normal;
+  --text-3-font-family: gosttypeb-standard, sans-serif;
+  --text-3-font-size: 20px;
+  --text-3-line-height: 24px;
+  --text-3-font-weight: 400;
+  --text-3-font-style: normal;
+  --text-3-line-font-family: gosttypeb-standard, sans-serif;
+  --text-3-line-font-size: 20px;
+  --text-3-line-line-height: 24px;
+  --text-3-line-font-weight: 400;
+  --text-3-line-font-style: normal;
+  --text-tel-1-font-family: gosttypeb-standard, sans-serif;
+  --text-tel-1-font-size: 20px;
+  --text-tel-1-line-height: 24px;
+  --text-tel-1-font-weight: 400;
+  --text-tel-1-font-style: normal;
+  --text-tel-2-font-family: gosttypeb-standard, sans-serif;
+  --text-tel-2-font-size: 16px;
+  --text-tel-2-line-height: 18px;
+  --text-tel-2-font-weight: 400;
+  --text-tel-2-font-style: normal;
+  --text-tel-2-line-font-family: gosttypeb-standard, sans-serif;
+  --text-tel-2-line-font-size: 16px;
+  --text-tel-2-line-line-height: 18px;
+  --text-tel-2-line-font-weight: 400;
+  --text-tel-2-line-font-style: normal;
+  --text-tel-3-font-family: gosttypeb-standard, sans-serif;
+  --text-tel-3-font-size: 14px;
+  --text-tel-3-line-height: 14px;
+  --text-tel-3-font-weight: 400;
+  --text-tel-3-font-style: normal;
+  --text-tel-1-line-font-family: gosttypeb-standard, sans-serif;
+  --text-tel-1-line-font-size: 20px;
+  --text-tel-1-line-line-height: 24px;
+  --text-tel-1-line-font-weight: 400;
+  --text-tel-1-line-font-style: normal;
 
-$error: #bf1700; // Ошибки
-$error-for-dark: #fa391f; // Ошибки на тёмном фоне
-
-// Gradient Кнопка на главном экране
-$gradient1: #0c3483;
-$gradient2: #4767a7;
-$gradient3: #a2b6df;
-$gradient4: #fff;
-
-// Gradient_bg Фон на главном экране
-$gradient-bg1: #0c3483;
-$gradient-bg2: #a2b6df;
-$gradient-bg3: #6b8cce;
+  /* Effects */
+  --shadow-box-shadow: 0px 10px 20px 0px rgb(0 45 99 / 30%);
+}


### PR DESCRIPTION
- экспортировал из css всю палитру со всеми возможными переменными из макета фигмы (AutoHTML лучший плагин на земле)
- шрифты теперь подключаются в едином файле и потом импортируются в index.scss
- у каждого шрифта добавил alias на всякий случай. Смотря как из фигмы эти шрифты доставать. Если через инспектора то одно название, если через экспорт CSS то другое. Но и то и то название будет работать. Например:
  - Germano-Regular
  - Germano
- раз файл normalize.css у нас теперь в папке проекта, styleLint до него не дотянется.
